### PR TITLE
fix: hardcode black text for comment popup textarea

### DIFF
--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -127,6 +127,7 @@ export default class LeetcodeTracker {
         box-sizing: border-box;
         border: 1px solid #E0E0E0;
         border-radius: 8px;
+        color: rgb(0, 0, 0);
         font-family: inherit;
         font-size: 14px;
         margin-bottom: 20px;


### PR DESCRIPTION
Resolves #12.

As mentioned in the original issue, please let me know if I should raise a feature request for full Dark Mode support - which I would be happy to work on if time allows!

# Proof of Work

See the updated comment popup with hardcoded text `color` in dark mode:

![image](https://github.com/user-attachments/assets/2a90ce2d-dac6-49cc-8107-f2225618bc05)