### PR TITLE
feature: add sql support

### DIFF
--- a/scripts/constants/languages.js
+++ b/scripts/constants/languages.js
@@ -18,10 +18,13 @@ export const baseLanguages = {
   racket: { langName: "racket", extension: ".rkt" },
   erlang: { langName: "erlang", extension: ".erl" },
   elixir: { langName: "elixir", extension: ".ex" },
+  mysql: { langName: "mysql", extension: ".sql" },
+  postgresql: { langName: "postgresql", extension: ".sql" },
 };
 
 export const alternativeNames = {
   "c++": "cpp",
   "c#": "csharp",
   go: "golang",
+  postgres: "postgresql",
 };

--- a/scripts/services/github-service.js
+++ b/scripts/services/github-service.js
@@ -402,6 +402,13 @@ export default class GithubService {
           end: "|#",
           linePrefix: " ",
         };
+      case ".sql":
+        return {
+          line: "--",
+          start: "/*",
+          end: "*/",
+          linePrefix: " * ",
+        };
       default:
         // Default to C-style comments for unknown languages
         return {


### PR DESCRIPTION
**What I’ve done**
I cloned the repo and tested the extension locally. I made the following changes to add SQL support:

languages.js:
Added entries for MySQL and PostgreSQL with .sql extension
Also added an alias postgres → postgresql for consistency

github-service.js:
Updated getCommentFormat() to handle .sql files using SQL-style comments (-- and /* ... */)

**Test Results**
After the changes:

Submitting MySQL or PostgreSQL problems on LeetCode triggers the GitHub sync

.sql files are committed with proper formatting and headers

Syncing now works seamlessly for SQL solutions

<img width="2902" height="440" alt="image" src="https://github.com/user-attachments/assets/af7fe7cb-a963-4927-be43-66b77bea81a1" />
